### PR TITLE
Fix HTML MIME type

### DIFF
--- a/src/data.ts
+++ b/src/data.ts
@@ -75,7 +75,7 @@ export const mimeData: { [mime: string]: MimeData } = {
   },
   'application/gzip': { extensions: ['.gz', '.gzip'], label: 'GZip Compressed Archive', kind: FileKind.Archive },
   'image/gif': { extensions: ['.gif'], label: 'Graphics Interchange Format (GIF)', kind: FileKind.Image },
-  'application/html': {
+  'text/html': {
     extensions: ['.htm', '.html'],
     label: '.html	HyperText Markup Language (HTML)',
     kind: FileKind.Text,

--- a/src/mime.test.ts
+++ b/src/mime.test.ts
@@ -285,7 +285,7 @@ describe('mime', () => {
           [
             'application/x-csh',
             'text/css',
-            'application/html',
+            'text/html',
             'text/calendar',
             'text/javascript',
             'application/json',


### PR DESCRIPTION
Switch the HTML MIME type from application/html to text/html.
HTML is listed as text/html in iana media types:
https://www.iana.org/assignments/media-types/media-types.xhtml